### PR TITLE
Fix email regex validation

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -58,7 +58,7 @@ class _LoginScreenState extends State<LoginScreen> {
 
   String? _validateEmail(String? value) {
     if (value == null || value.isEmpty) return 'Ingresa tu correo';
-    final regex = RegExp(r'^\S+@\S+\.\S+\$');
+    final regex = RegExp(r'^\S+@\S+\.\S+$');
     if (!regex.hasMatch(value)) return 'Correo inválido';
     return null;
   }

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -58,7 +58,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
 
   String? _validateEmail(String? value) {
     if (value == null || value.isEmpty) return 'Ingresa tu correo';
-    final regex = RegExp(r'^\S+@\S+\.\S+\$');
+    final regex = RegExp(r'^\S+@\S+\.\S+$');
     if (!regex.hasMatch(value)) return 'Correo inválido';
     return null;
   }


### PR DESCRIPTION
## Summary
- correct regex to allow valid email addresses in login and register screens

## Testing
- `flutter pub get` *(fails: Because pancito requires SDK version ^3.7.2, version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_68475231c0048321bac0d5e08d136749